### PR TITLE
Only reset timeout in callback if it already exists

### DIFF
--- a/app/assets/javascripts/delayed_job_admin/poll_job.js.erb
+++ b/app/assets/javascripts/delayed_job_admin/poll_job.js.erb
@@ -26,7 +26,9 @@ var DELAYED_JOB_ADMIN = (function(dja, $) {
         if(data.status==='processing') {
           processing(data);
         }
-        polling_jobs[job_id] = window.setTimeout(poll, poll_interval);
+        if(polling_jobs[job_id]){
+          polling_jobs[job_id] = window.setTimeout(poll, poll_interval);
+        }
       }
     };
 
@@ -39,7 +41,7 @@ var DELAYED_JOB_ADMIN = (function(dja, $) {
       });
     };
 
-    poll();
+    polling_jobs[job_id] = window.setTimeout(poll, poll_interval);
   };
 
   dja.stop_polling_job = function(job_id){


### PR DESCRIPTION
This prevents resetting timeout after it has been cancelled.